### PR TITLE
Decommission: backup evidence, verification tooling, and report

### DIFF
--- a/DECOMMISSION.md
+++ b/DECOMMISSION.md
@@ -1,0 +1,85 @@
+# Decommission Report — `wwbp-bcfg-chatbot`
+
+**Date:** 2026-07-02/03 · **AWS account:** `336162656437` (us-east-1) · **Scope:** all environments (dev, test, prod)
+
+The application (AWS Copilot: `web` + `worker` + `scheduler` per env, Aurora Serverless v2 PostgreSQL, ElastiCache Redis) is being decommissioned. All persistent data lives in the per-env Aurora `chatbot` databases — static assets are whitenoise (in-image), Redis is an ephemeral Celery broker, and there is no S3 media storage. Every database was backed up **two independent ways** and every backup was **cryptographically verified** before any deletion.
+
+## 1. Backups (all verified ✅)
+
+### RDS manual cluster snapshots (primary, AWS-native restore)
+Manual snapshots survive cluster deletion indefinitely until explicitly deleted.
+
+| Env | Snapshot ID | Status |
+|---|---|---|
+| dev | `wwbp-bcfg-chatbot-dev-final-20260702` | available |
+| test | `wwbp-bcfg-chatbot-test-final-20260702` | available |
+| prod | `wwbp-bcfg-chatbot-prod-final-20260702` | available |
+
+### pg_dump archives (portable, restorable on any PostgreSQL ≥16)
+Stored in `s3://wwbp-bcfg-decom-backups-336162656437/` (SSE-AES256, public access blocked) with local copies retained. Each env has three artifacts: `.dump` (pg_dump `-Fc`), `.manifest` (per-table row count + content digest), `.sha256` (artifact hashes computed at source, inside the VPC, before upload).
+
+| Env | Dump size | `db.dump` SHA-256 | `db.manifest` SHA-256 |
+|---|---|---|---|
+| dev | 967 MB | `588fdbfc2503cd9eb3924e19612aa64224126cf73f806666d222cb41aa830905` | `86f8326fc71dea1818e23b6934a897eaee80fcedd8c4a2b33706886fbad432c1` |
+| test | 17 MB | `992afd3b169b36ce61ae289d0dc62b4d0d876787dcf0fe0e8bf23f2c06a78e25` | `2ac29ff261a02f066550b19dfe8b6689124d266c3e0fbb80d3b57b90876a1357` |
+| prod | 2.6 GB | `73f0875a62481cc0beb219dd8731b74adec0021d4e293047c9ac5915f9147a13` | `99ecff08159233d14dfaa983a63519a6b96bbe2bde42daf915d9d8661aa48578` |
+
+Database credentials for all three clusters were exported from Secrets Manager before teardown (held privately offline, not in this repo).
+
+## 2. Verification methodology
+
+Tooling in [`decommission/`](decommission/). Each env was **quiesced** (all ECS services scaled to 0 and drained) before backup, so snapshot, dump, and manifest describe the same instant.
+
+**Layer 1 — artifact integrity.** SHA-256 of the dump computed *inside the VPC* immediately after `pg_dump`, re-computed after download. Detects any transfer/storage corruption. All three envs: exact match.
+
+**Layer 2 — logical integrity.** [`manifest.sql`](decommission/dump-task/manifest.sql) fingerprints every table: exact row count + an order-independent SHA-256 content digest (SHA-256 over the sorted per-row SHA-256s of `row::text`, rendered under pinned GUCs: `TimeZone=UTC, DateStyle=ISO, IntervalStyle=postgres, extra_float_digits=3, bytea_output=hex`). The dump is restored into a scratch server with `pg_restore --exit-on-error`, re-fingerprinted with the same file, and diffed against the source manifest. All three envs: every table identical (dev 50/50 tables; test all; prod all).
+
+The gate caught (and we root-caused) three false-mismatch classes before declaring success — these are why the pinning above exists:
+1. **Session `TimeZone`** flips `timestamptz::text` rendering (37 dev tables) → pinned UTC both sides.
+2. **Sort collation** (Linux C vs macOS en_US.UTF-8) reorders manifest lines → `LC_ALL=C sort` both sides.
+3. **libc `isspace()`**: on macOS, `record_out` quotes fields containing certain multibyte UTF-8 bytes (e.g. `0xA0` inside `☠️`), glibc does not — *same PostgreSQL version renders differently across libc*. Verified prod on a glibc `postgres:16.11` container matching Aurora exactly. **Logical verification must run on glibc.**
+
+A cross-run consistency check also passed: two dump-task runs 1 hour apart (quiesced DB) produced byte-identical manifests.
+
+## 3. Restore instructions
+
+**From snapshot (full cluster):**
+```bash
+aws rds restore-db-cluster-from-snapshot \
+  --db-cluster-identifier <new-name> \
+  --snapshot-identifier wwbp-bcfg-chatbot-<env>-final-20260702 \
+  --engine aurora-postgresql
+# then create a db.serverless writer instance in the new cluster
+```
+
+**From pg_dump (any PostgreSQL ≥ 16):**
+```bash
+aws s3 cp s3://wwbp-bcfg-decom-backups-336162656437/<env>-chatbot-20260702.dump .
+shasum -a 256 <env>-chatbot-20260702.dump   # compare against table above
+createdb chatbot && pg_restore --exit-on-error --no-owner --no-privileges -d chatbot <env>-chatbot-20260702.dump
+# optional full re-verification:
+decommission/verify/verify-dump.sh <env>-chatbot-20260702.{dump,manifest,sha256}
+```
+
+## 4. Teardown log
+
+| Step | Status |
+|---|---|
+| dev services (web/worker/scheduler stacks) | ✅ deleted |
+| dev addons stack (Aurora cluster, Redis, DB secret) | ✅ deleted (CFN also left an extra automatic final snapshot) |
+| dev env stack (ALB, VPC, subnets) | 🔄 in progress at time of writing |
+| test/prod services + env | ⏳ pending (order: purge ALB-logs bucket → addons stack → services → env) |
+| `copilot app delete`, `task-django-bcfg-twilio` helper stack, ECR repos | ⏳ pending (last) |
+
+Operational findings (for anyone repeating this):
+- `copilot env delete` fails against env addons that import env exports (aws/copilot-cli#4730): **delete the addons CFN stack first**.
+- The ALB access-logs buckets are **versioned**; copilot's bucket cleaner fails on them (and crashes on already-empty buckets — `--retain-resources` the `ELBAccessLogsBucketCleanerAction` custom resource on retry). Purge all versions + delete markers manually.
+- Four hand-launched EC2 instances (3× Bitbucket CI runners from 2025-04, 1× DB-tunnel bastion from 2025-09) lived in the dev VPC outside CloudFormation and blocked subnet/IGW deletion; terminated with owner approval on 2026-07-03.
+- The dump task needs `linux/amd64` images (`DOCKER_DEFAULT_PLATFORM=linux/amd64` when building on Apple Silicon) and an S3 `PutObject` grant on copilot's default task role.
+
+## 5. Retained artifacts
+
+- 3 manual RDS snapshots + CFN automatic finals (delete the automatics whenever; keep the manuals)
+- `s3://wwbp-bcfg-decom-backups-336162656437/` — 9 verified artifacts
+- Offline: local artifact copies + DB credential exports
+- ACM certificate `34771f1b-e42a-4e00-b725-551b6459e3d8` (`*.wwbp-bcfg-chatbot.org`) — not deleted; decide separately with DNS

--- a/decommission/dump-task/Dockerfile
+++ b/decommission/dump-task/Dockerfile
@@ -1,0 +1,10 @@
+# One-off image for logical DB export from inside the Copilot env VPC.
+# postgres:16 provides pg_dump + psql (matches Aurora PG 16.11); add awscli + python3.
+FROM postgres:16
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends awscli ca-certificates python3 \
+    && rm -rf /var/lib/apt/lists/*
+COPY manifest.sql /manifest.sql
+COPY dump.sh /usr/local/bin/dump.sh
+RUN chmod +x /usr/local/bin/dump.sh
+ENTRYPOINT ["/usr/local/bin/dump.sh"]

--- a/decommission/dump-task/dump.sh
+++ b/decommission/dump-task/dump.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Runs INSIDE the Copilot env VPC (Fargate) to reach the private Aurora cluster.
+# Emits THREE artifacts to S3 (DB must be quiesced/static first):
+#   <env>.dump       pg_dump custom-format archive (portable backup)
+#   <env>.manifest   per-table row count + SHA-256 content digest (logical fingerprint)
+#   <env>.sha256     SHA-256 of the .dump and .manifest (artifact fingerprint, computed AT SOURCE)
+set -euo pipefail
+: "${DB_SECRET:?}"; : "${DUMP_BUCKET:?}"; : "${DUMP_KEY:?}"; : "${MANIFEST_KEY:?}"; : "${SHA_KEY:?}"
+
+j(){ printf '%s' "$DB_SECRET" | python3 -c "import sys,json;print(json.load(sys.stdin).get('$1',''))"; }
+HOST=$(j host); PORT=$(j port); USER=$(j username); DB=$(j dbname); export PGPASSWORD; PGPASSWORD=$(j password)
+[ -n "$PORT" ] || PORT=5432; [ -n "$DB" ] || DB=chatbot
+CONN="host=$HOST port=$PORT user=$USER dbname=$DB sslmode=${PGSSLMODE:-require}"
+
+echo ">> pg_dump -> /tmp/db.dump"
+pg_dump "$CONN" -Fc --no-owner --no-privileges -f /tmp/db.dump
+
+echo ">> source logical manifest -> /tmp/db.manifest"
+# Pin every GUC that affects ::text rendering (must match verify-dump.sh exactly)
+PGOPTIONS="-c TimeZone=UTC -c DateStyle=ISO,YMD -c IntervalStyle=postgres -c extra_float_digits=3 -c bytea_output=hex -c lc_monetary=C" \
+  psql "$CONN" -At -f /manifest.sql | LC_ALL=C sort > /tmp/db.manifest
+
+echo ">> source SHA-256 (artifact fingerprint)"
+( cd /tmp && sha256sum db.dump db.manifest ) > /tmp/db.sha256
+cat /tmp/db.sha256
+
+echo ">> upload to s3://$DUMP_BUCKET/"
+aws s3 cp /tmp/db.dump     "s3://$DUMP_BUCKET/$DUMP_KEY"
+aws s3 cp /tmp/db.manifest "s3://$DUMP_BUCKET/$MANIFEST_KEY"
+aws s3 cp /tmp/db.sha256   "s3://$DUMP_BUCKET/$SHA_KEY"
+echo ">> done"

--- a/decommission/dump-task/manifest.sql
+++ b/decommission/dump-task/manifest.sql
@@ -1,0 +1,23 @@
+-- manifest.sql — logical integrity fingerprint of every table in a database.
+-- Per table: exact row count + order-independent SHA-256 content digest
+-- (SHA-256 over the SORTED SHA-256 of every row, so row order / physical layout don't matter).
+-- sha256() is a Postgres built-in since v11 (no pgcrypto extension needed).
+-- Run against SOURCE (static) and against each RESTORE; diff the outputs.
+--   psql "$CONN" -At -f manifest.sql | sort > manifest.txt      (output: schema.table|rows|sha256hex)
+-- No text-emitting meta-commands: output stays pure data so the fingerprint is byte-identical
+-- regardless of which psql build runs it (container vs local).
+
+SELECT format(
+  'SELECT %L AS k, count(*)::text AS rows, '
+  || 'coalesce(encode(sha256(convert_to('
+  || 'string_agg(encode(sha256(convert_to(t.*::text, ''UTF8'')), ''hex''), '''' '
+  || 'ORDER BY encode(sha256(convert_to(t.*::text, ''UTF8'')), ''hex'')), '
+  || '''UTF8'')), ''hex''), ''EMPTY'') AS digest '
+  || 'FROM %I.%I t',
+  n.nspname || '.' || c.relname, n.nspname, c.relname)
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = 'r'
+  AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+ORDER BY n.nspname, c.relname
+\gexec

--- a/decommission/verify/verify-dump.sh
+++ b/decommission/verify/verify-dump.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# TWO-LAYER integrity gate. Exit 0 = PASS, non-zero = FAIL (do NOT tear down).
+#   Layer 1 (artifact):  local sha256 of the downloaded .dump == source sha256  -> no transfer bit-rot
+#   Layer 2 (logical):   clean pg_restore (--exit-on-error) + row counts & SHA-256 digests == source
+# Usage: ./verify-dump.sh <env.dump> <env.manifest> <env.sha256>
+set -euo pipefail
+DUMP="${1:?.dump}"; SRC_MANIFEST="${2:?.manifest}"; SRC_SHA="${3:?.sha256 from source}"
+PG_BIN="/opt/homebrew/opt/postgresql@16/bin"; export PATH="$PG_BIN:$PATH"
+HERE="$(cd "$(dirname "$0")" && pwd)"; SCRATCH="verify_scratch_$$"
+"$PG_BIN/pg_isready" -q || { echo "start local pg: brew services start postgresql@16"; exit 1; }
+
+echo "== LAYER 1: artifact SHA-256 =="
+# source .sha256 lines look like: "<hex>  db.dump". Pull the dump's expected hash.
+WANT=$(awk '/db\.dump$/{print $1}' "$SRC_SHA"); [ -n "$WANT" ] || { echo "no db.dump hash in $SRC_SHA"; exit 3; }
+GOT=$(shasum -a 256 "$DUMP" | awk '{print $1}')
+echo "   source=$WANT"; echo "   local =$GOT"
+[ "$WANT" = "$GOT" ] || { echo "   FAIL: dump sha256 mismatch (transfer corruption)"; exit 2; }
+echo "   ok: archive bytes intact"
+
+echo "== LAYER 2: clean restore + logical fingerprint =="
+pg_restore --list "$DUMP" >/dev/null && echo "   TOC valid"
+createdb "$SCRATCH"; trap 'dropdb --if-exists "$SCRATCH"' EXIT
+pg_restore --exit-on-error --no-owner --no-privileges -d "$SCRATCH" "$DUMP"
+echo "   restored with zero errors"
+# Pin every GUC that affects ::text rendering so digests are canonical across servers/sessions
+# (must match dump.sh exactly; unpinned TimeZone alone flips every timestamptz digest)
+export PGOPTIONS="-c TimeZone=UTC -c DateStyle=ISO,YMD -c IntervalStyle=postgres -c extra_float_digits=3 -c bytea_output=hex -c lc_monetary=C"
+psql "dbname=$SCRATCH" -At -f "$HERE/../dump-task/manifest.sql" | LC_ALL=C sort > restored-manifest.txt
+# canonically re-sort BOTH sides (C collation) so sort-locale differences can never mask/flag anything
+LC_ALL=C sort "$SRC_MANIFEST" > src-manifest.sorted
+if diff -u src-manifest.sorted restored-manifest.txt; then
+  echo "   PASS: row counts + SHA-256 digests identical for every table."
+else
+  echo "   FAIL: logical manifest differs (see diff)."; exit 2
+fi
+echo "ALL CHECKS PASSED"


### PR DESCRIPTION
## Summary
- The app is being decommissioned (AWS account `336162656437`). This PR records the evidence and adds the tooling used.
- All 3 Aurora `chatbot` DBs backed up twice: **manual RDS snapshots** (`wwbp-bcfg-chatbot-<env>-final-20260702`) + **pg_dump archives** in `s3://wwbp-bcfg-decom-backups-336162656437/`.
- Every backup passed a **two-layer SHA-256 verification** (artifact integrity end-to-end from inside the VPC; logical integrity via full restore + per-table rowcount/content-digest comparison against the quiesced source). Evidence hashes in `DECOMMISSION.md`.
- `decommission/` contains the reusable tooling: in-VPC dump Fargate image (`dump-task/`) and the restore-verification gate (`verify/verify-dump.sh`).
- Teardown in progress: dev services + Aurora/Redis deleted; dev VPC finishing; test/prod next; `copilot app delete` last. Findings for repeating safely (copilot-cli#4730 ordering, versioned log buckets, libc-dependent `record_out` rendering) documented in the report.

## Test plan
- [x] Verification tooling smoke-tested locally (pass path, corrupted-archive path, tampered-row path)
- [x] Layer 1+2 verification passed for dev (50/50 tables), test, prod (on glibc postgres:16.11 matching Aurora)

🤖 Generated with [Claude Code](https://claude.com/claude-code)